### PR TITLE
Revert all the changes to indexing.

### DIFF
--- a/src/basiskaart/hoogteligging.py
+++ b/src/basiskaart/hoogteligging.py
@@ -167,19 +167,11 @@ def geo_index(schema, table, geo_field):
 
     table_lower = table.lower()
 
-    # Extended logic not only creates geo indexes.
-    #  But first clustering objects by geo coordinates
-    #  on disk for faster access.
-    #  credits for this solution go to: Edward Mac Gillavry
     s = f"""
-    SET SEARCH_PATH TO {schema},public;
-    CREATE INDEX index_{table_lower}_geohash_idx
-     ON "{table}" (ST_GeoHash(ST_Transform(
-        ST_Envelope({geo_field}),4326),10) COLLATE "C");
-    CLUSTER "{table}" USING "index_{table_lower}_geohash_idx";
-    DROP INDEX index_{table_lower}_geohash_idx;
-    CREATE INDEX IF NOT EXISTS index_{table_lower}_gist
-      ON "{table}" USING gist({geo_field});
+    SET SEARCH_PATH TO {schema};
+    CREATE INDEX IF NOT EXISTS index_{table_lower}_gist ON "{table}"
+    USING gist({geo_field});
+    CLUSTER "{table}" USING "index_{table_lower}_gist";
     """
 
     sql.run_sql(s)
@@ -249,28 +241,9 @@ def create_indexes():
     """
     Create GEO indexes and column btree indexes for all schemas
     """
-
-    initial_work_mem = None
-    initial_maintenance_work_mem = None
-    try:
-        initial_work_mem = sql.run_sql("SHOW work_mem")[0][0]
-        initial_maintenance_work_mem = sql.run_sql(
-            "SHOW maintenance_work_mem")[0][0]
-    except Exception:
-        log.debug("Failed to fetch initial work memory setting")
-
-    if initial_work_mem is not None:
-        sql.run_sql_no_results("SET work_mem TO '2GB';")
-        sql.run_sql_no_results("SET maintenance_work_mem TO '1GB';")
-
     for schema in ['kbk10', 'kbk25', 'kbk50', 'bgt']:
         make_indexes_on_all_tables(schema)
         make_geoindexes_on_all_matviews(schema)
-
-    if initial_work_mem is not None:
-        sql.run_sql_no_results(f"SET work_mem TO '{initial_work_mem}';")
-        sql.run_sql_no_results(
-            f"SET maintenance_work_mem TO '{initial_maintenance_work_mem}';")
 
 
 # Keep track of columns, views and counts to


### PR DESCRIPTION
Current approach failed due to number of issues. Reverting changes to import and applying same clustering on build step, as we already did for topo layer.